### PR TITLE
Prepopulate the challenge directory from the last used config

### DIFF
--- a/infrastructure/kubernetes/scripts/setup/config-create.sh
+++ b/infrastructure/kubernetes/scripts/setup/config-create.sh
@@ -42,6 +42,14 @@ echo
 echo " Note: This will also change the location of the config file!"
 echo
 read_config CHAL_DIR "In which directory will challenges be stored?"
+if [ "${CHAL_DIR}" != $(realpath -L "${CHAL_DIR}") ]; then
+    CHAL_DIR=$(realpath -L "${CHAL_DIR}")
+    echo
+    echo " The challenge directory appears to be a relative path."
+    echo
+    read_config CHAL_DIR "Please confirm the absolute path or type a different directory"
+fi
+echo
 if [ ! -d "${CHAL_DIR}" ]; then
     echo "${CHAL_DIR} does not exist yet. Creating it."
     mkdir -p "${CHAL_DIR}"
@@ -102,7 +110,7 @@ echo
 read_config DOMAIN_NAME "Domain name (eg, k8s.ctfcompetititon.com)"
 echo
 echo "= SUMMARY ="
-echo " This is the configuration for your cluster, please review it to make sure it is correct."
+echo " This is the configuration for your cluster, please review it to make sure it is correct. It will be written to ${CONFIG_FILE}"
 echo "$config"
 echo
 echo " If you wish to change anything, just run this command again."

--- a/infrastructure/kubernetes/scripts/setup/config-create.sh
+++ b/infrastructure/kubernetes/scripts/setup/config-create.sh
@@ -37,7 +37,7 @@ else
     echo
 fi
 echo
-echo "= CHALLENGES DIRECTORY ="
+echo "== CHALLENGES DIRECTORY =="
 echo
 echo " Note: This will also change the location of the config file!"
 echo

--- a/infrastructure/kubernetes/scripts/setup/config-create.sh
+++ b/infrastructure/kubernetes/scripts/setup/config-create.sh
@@ -22,28 +22,31 @@ read_config() {
     config="${config}"$'\n'"${line}"
 }
 
-echo "= Challenges Directory ="
 echo
-read -e -p "  In which directory will challenges be stored?: " "CHAL_DIR"
-eval CHAL_DIR="${CHAL_DIR}"
+echo "= CLUSTER CONFIGURATION ="
+echo
+HOME_CONFIG_FILE="${HOME}/.config/kctf/cluster.conf"
+if test -f "$HOME_CONFIG_FILE"; then
+    echo
+    echo " Reusing the last config file used ($(readlink -f "${HOME_CONFIG_FILE}"))."
+    echo
+    . "${HOME_CONFIG_FILE}"
+else
+    echo
+    echo " Creating a new config file from scratch."
+    echo
+fi
+echo
+echo "= CHALLENGES DIRECTORY ="
+echo
+echo " Note: This will also change the location of the config file!"
+echo
+read_config CHAL_DIR "In which directory will challenges be stored?"
 if [ ! -d "${CHAL_DIR}" ]; then
-    echo "creating ${CHAL_DIR}"
+    echo "${CHAL_DIR} does not exist yet. Creating it."
     mkdir -p "${CHAL_DIR}"
 fi
-line=$(declare -p "CHAL_DIR")
-config="${config}"$'\n'"${line}"
-echo
-
 CONFIG_FILE="${CHAL_DIR}/kctf.conf"
-if test -f "$CONFIG_FILE"; then
-    echo "= WARNING ="
-    read -s -p "Config file already exists, this program will overwrite it. Press Ctrl+C to cancel, Enter to continue."
-    echo
-    echo
-    . "$CONFIG_FILE"
-fi
-
-echo "= CLUSTER CONFIGURATION ="
 echo
 echo "== PROJECT NAME =="
 echo
@@ -104,6 +107,7 @@ echo "$config"
 echo
 echo " If you wish to change anything, just run this command again."
 
-mkdir -p "${HOME}/.config/kctf"
-echo "${config}" > "$CONFIG_FILE"
-ln -fs "${CONFIG_FILE}" "${HOME}/.config/kctf/cluster.conf"
+echo "${config}" > "${CONFIG_FILE}"
+
+mkdir -p $(dirname "${HOME_CONFIG_FILE}")
+ln -fs "${CONFIG_FILE}" "${HOME_CONFIG_FILE}"


### PR DESCRIPTION
In https://github.com/google/google-ctf/commit/b54300c2692d8788cb7d22c508c1a1c94ce6a5b3#diff-d52794853b3ece4222dd2dbb817a431c the user now always has to type the challenge directory.

It's likely people will base new configs based on old configs, and that script is also meant to be used to edit and copy cluster configurations.

These change makes it so that the default values will be loaded from the last configuration used, if available. And then, we still ask the CHAL_DIR, but now only after loading the config file.