### PR TITLE
Add readiness probe

### DIFF
--- a/infrastructure/kctf/base/challenge-skeleton/k8s/containers.yaml
+++ b/infrastructure/kctf/base/challenge-skeleton/k8s/containers.yaml
@@ -40,6 +40,14 @@ spec:
         - name: "config"
           mountPath: "/config"
           readOnly: true
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 20
+          timeoutSeconds: 3
+          periodSeconds: 30
         livenessProbe:
           failureThreshold: 2
           httpGet:

--- a/infrastructure/kctf/base/challenge-skeleton/k8s/containers.yaml
+++ b/infrastructure/kctf/base/challenge-skeleton/k8s/containers.yaml
@@ -40,20 +40,19 @@ spec:
         - name: "config"
           mountPath: "/config"
           readOnly: true
-        readinessProbe:
-          failureThreshold: 2
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 20
-          timeoutSeconds: 3
-          periodSeconds: 30
         livenessProbe:
           failureThreshold: 2
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 20
+          initialDelaySeconds: 45
+          timeoutSeconds: 3
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 30
           timeoutSeconds: 3
           periodSeconds: 30
       - name: "healthcheck"


### PR DESCRIPTION
This will ensure that broken tasks don't get traffic routed to them