### PR TITLE
Fix xss-bot healthcheck and enable it

### DIFF
--- a/infrastructure/kctf-samples/xss-bot/chal.conf
+++ b/infrastructure/kctf-samples/xss-bot/chal.conf
@@ -1,4 +1,4 @@
 # this file will be sourced by the deployment scripts
 DEPLOY=true
 PUBLIC=false
-HEALTHCHECK=false
+HEALTHCHECK=true

--- a/infrastructure/kctf-samples/xss-bot/healthcheck/exploit/doit.py
+++ b/infrastructure/kctf-samples/xss-bot/healthcheck/exploit/doit.py
@@ -1,22 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# without this pwntools throws an error
-import curses
-curses.setupterm('xterm-256color')
-
 import socket
 from pwn import *
 
-LISTEN_PORT = 15123
-
-socket.setdefaulttimeout(10)
-
 r = remote('127.0.0.1', 1337)
+l = listen()
 
-serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-serversocket.bind(("127.0.0.1", LISTEN_PORT))
-serversocket.listen(1)
+r.readuntil('URL to open.', timeout=10)
+r.send('http://localhost:{}/ok'.format(l.lport))
 
-r.sendlineafter('Please send me a URL to open.', 'http://localhost:{}/ok'.format(LISTEN_PORT))
-serversocket.accept()
+_ = l.wait_for_connection()
+l.readuntil('GET /ok HTTP/1.1')
+
+exit (0)

--- a/infrastructure/kctf-samples/xss-bot/healthcheck/exploit/run.sh
+++ b/infrastructure/kctf-samples/xss-bot/healthcheck/exploit/run.sh
@@ -5,12 +5,17 @@ set -Eeuo pipefail
 TIMEOUT=20
 PERIOD=30
 
+export TERM=linux
+export TERMINFO=/etc/terminfo
+
 while true; do
   source /config/env
-  if timeout "${TIMEOUT}" /exploit/doit.py; then
-    echo 'ok' > /tmp/healthz
+  echo -n "[$(date)] "
+  if timeout "${TIMEOUT}" /exploit/doit.py NOTERM; then
+    echo 'ok' | tee /tmp/healthz
   else
-    echo 'err' > /tmp/healthz
+    echo -n "$? "
+    echo 'err' | tee /tmp/healthz
   fi
   sleep "${PERIOD}"
 done

--- a/infrastructure/kctf/base/challenge-skeleton/healthcheck/exploit/doit.py
+++ b/infrastructure/kctf/base/challenge-skeleton/healthcheck/exploit/doit.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# without this pwntools throws an error
-import curses
-curses.setupterm('xterm-256color')
-
 from pwn import *
 
 exit(0)

--- a/infrastructure/kctf/base/challenge-skeleton/healthcheck/exploit/run.sh
+++ b/infrastructure/kctf/base/challenge-skeleton/healthcheck/exploit/run.sh
@@ -7,10 +7,12 @@ PERIOD=30
 
 while true; do
   source /config/env
-  if timeout "${TIMEOUT}" /exploit/doit.py; then
-    echo 'ok' > /tmp/healthz
+  echo -n "[$(date)] "
+  if timeout "${TIMEOUT}" /exploit/doit.py NOTERM; then
+    echo 'ok' | tee /tmp/healthz
   else
-    echo 'err' > /tmp/healthz
+    echo -n "$? "
+    echo 'err' | tee /tmp/healthz
   fi
   sleep "${PERIOD}"
 done


### PR DESCRIPTION
The xss-bot healthcheck fails at times when the port 15123 is being used (either by a previous invocation of the healthcheck or otherwise), this makes it so that it chooses a random port every time.

In addition, this launches pwntools with NOTERM and the TERM+TERMLIB environment variables instead of explicitly calling ncurses.